### PR TITLE
Add basic CPX board

### DIFF
--- a/libs/adafruit-circuit-playground/README.md
+++ b/libs/adafruit-circuit-playground/README.md
@@ -1,0 +1,4 @@
+# adafruit
+
+The adafruit library.
+

--- a/libs/adafruit-circuit-playground/_locales/circuit-playground-jsdoc-strings.json
+++ b/libs/adafruit-circuit-playground/_locales/circuit-playground-jsdoc-strings.json
@@ -1,0 +1,13 @@
+{
+  "input": "Respond to and read data from buttons and sensors.\n\nEvents and data from sensors.",
+  "input.buttonA": "Left button.",
+  "input.buttonB": "Right button.",
+  "input.buttonsAB": "Left and Right button.",
+  "input.pinA1": "Capacitive pin A1",
+  "input.pinA2": "Capacitive pin A2",
+  "input.pinA3": "Capacitive pin A3",
+  "input.pinA4": "Capacitive pin A4",
+  "input.pinA5": "Capacitive pin A5",
+  "input.pinA6": "Capacitive pin A6",
+  "input.pinA7": "Capacitive pin A7"
+}

--- a/libs/adafruit-circuit-playground/_locales/circuit-playground-strings.json
+++ b/libs/adafruit-circuit-playground/_locales/circuit-playground-strings.json
@@ -1,0 +1,16 @@
+{
+  "input.buttonA|block": "button A",
+  "input.buttonB|block": "button B",
+  "input.buttonsAB|block": "buttons A+B",
+  "input.pinA1|block": "pin A1",
+  "input.pinA2|block": "pin A2",
+  "input.pinA3|block": "pin A3",
+  "input.pinA4|block": "pin A4",
+  "input.pinA5|block": "pin A5",
+  "input.pinA6|block": "pin A6",
+  "input.pinA7|block": "pin A7",
+  "input|block": "input",
+  "{id:category}Config": "Config",
+  "{id:category}Input": "Input",
+  "{id:category}Pins": "Pins"
+}

--- a/libs/adafruit-circuit-playground/config.ts
+++ b/libs/adafruit-circuit-playground/config.ts
@@ -1,0 +1,46 @@
+namespace config {
+    export const NUM_NEOPIXELS = 10;
+    export const DEFAULT_BUTTON_MODE = DAL.BUTTON_ACTIVE_HIGH_PULL_DOWN;
+
+    export const PIN_FLASH_MISO = DAL.PA16;
+    export const PIN_FLASH_MOSI = DAL.PA20;
+    export const PIN_FLASH_SCK = DAL.PA21;
+    export const PIN_FLASH_CS = DAL.PB22;
+    export const PIN_MIC_DATA = DAL.PA08;
+    export const PIN_MIC_CLOCK = DAL.PA10;
+    export const PIN_BTN_SLIDE = DAL.PA15;
+    export const PIN_NEOPIXEL = DAL.PB23;
+    export const PIN_SPEAKER_AMP = DAL.PA30;
+    export const PIN_MICROPHONE = DAL.PA08;
+    export const PIN_LIGHT = DAL.PA11;
+    export const PIN_ACCELEROMETER_SDA = DAL.PA00;
+    export const PIN_ACCELEROMETER_SCL = DAL.PA01;
+    export const PIN_ACCELEROMETER_INT = DAL.PA13;
+    export const PIN_TEMPERATURE = DAL.PA09;
+    export const PIN_IR_OUT = DAL.PA23;
+    export const PIN_IR_IN = DAL.PA12;
+    export const PIN_BTN_A = DAL.PA28;
+    export const PIN_BTN_B = DAL.PA14;
+
+    export const PIN_A0 = DAL.PA02;
+    export const PIN_A1 = DAL.PA05;
+    export const PIN_A2 = DAL.PA06;
+    export const PIN_A3 = DAL.PA07;
+    export const PIN_A4 = DAL.PB03;
+    export const PIN_A5 = DAL.PB02;
+    export const PIN_A6 = DAL.PB09;
+    export const PIN_A7 = DAL.PB08;
+    export const PIN_SCL = DAL.PB03;
+    export const PIN_SDA = DAL.PB02;
+    export const PIN_RX = DAL.PB09;
+    export const PIN_TX = DAL.PB08;
+    export const PIN_A8 = DAL.PA11;
+    export const PIN_A9 = DAL.PA09;
+    export const PIN_D4 = DAL.PA28;
+    export const PIN_D5 = DAL.PA14;
+    export const PIN_D7 = DAL.PA15;
+    export const PIN_D8 = DAL.PB23;
+    export const PIN_D13 = DAL.PA17;
+    export const PIN_LED = DAL.PA17;
+    export const PIN_A10 = DAL.PA08;
+}

--- a/libs/adafruit-circuit-playground/device.d.ts
+++ b/libs/adafruit-circuit-playground/device.d.ts
@@ -1,0 +1,123 @@
+declare namespace pins {
+    // pin-pads
+    //% fixedInstance shim=pxt::getPin(PIN_A0)
+    const A0: PwmPin;
+    //% fixedInstance shim=pxt::getPin(PIN_A1)
+    const A1: PwmPin;
+    //% fixedInstance shim=pxt::getPin(PIN_A2)
+    const A2: PwmPin;
+    //% fixedInstance shim=pxt::getPin(PIN_A3)
+    const A3: PwmPin;
+
+    //% fixedInstance shim=pxt::getPin(PIN_A4)
+    const A4: PwmPin;
+    //% fixedInstance shim=pxt::getPin(PIN_A5)
+    const A5: PwmPin;
+    //% fixedInstance shim=pxt::getPin(PIN_A6)
+    const A6: PwmPin;
+    //% fixedInstance shim=pxt::getPin(PIN_A7)
+    const A7: PwmPin;
+
+    // Define aliases, as Digital Pins
+
+    //% fixedInstance shim=pxt::getPin(PIN_A4)
+    const SCL: DigitalPin;
+    //% fixedInstance shim=pxt::getPin(PIN_A5)
+    const SDA: DigitalPin;
+    //% fixedInstance shim=pxt::getPin(PIN_A6)
+    const RX: DigitalPin;
+    //% fixedInstance shim=pxt::getPin(PIN_A7)
+    const TX: DigitalPin;
+
+    // Aliases for built-in components
+
+    //% fixedInstance shim=pxt::getPin(PIN_A8)
+    const A8: PwmPin; // light
+    //% fixedInstance shim=pxt::getPin(PIN_A9)
+    const A9: PwmPin;
+    //% fixedInstance shim=pxt::getPin(PIN_D4)
+    const D4: DigitalPin; // A
+    //% fixedInstance shim=pxt::getPin(PIN_D5)
+    const D5: DigitalPin; // B
+    //% fixedInstance shim=pxt::getPin(PIN_D7)
+    const D7: DigitalPin; // Slide
+    //% fixedInstance shim=pxt::getPin(PIN_D8)
+    const D8: DigitalPin; // Neopixel
+
+    //% fixedInstance shim=pxt::getPin(PIN_D13)
+    const D13: DigitalPin;
+    //% fixedInstance shim=pxt::getPin(PIN_D13)
+    const LED: DigitalPin;
+
+    //% fixedInstance shim=pxt::getPin(PIN_A10)
+    const A10: PwmPin; // mic
+}
+
+
+declare namespace input {
+    /**
+     * Left button.
+     */
+    //% indexedInstanceNS=input indexedInstanceShim=pxt::getButton
+    //% block="button A" weight=95 fixedInstance
+    //% shim=pxt::getButton(0)
+    const buttonA: Button;
+
+    /**
+     * Right button.
+     */
+    //% block="button B" weight=94 fixedInstance
+    //% shim=pxt::getButton(1)
+    const buttonB: Button;
+
+    /**
+     * Left and Right button.
+     */
+    //% block="buttons A+B" weight=93 fixedInstance
+    //% shim=pxt::getButton(2)
+    const buttonsAB: Button;
+}
+
+declare namespace input {
+    /**
+     * Capacitive pin A1
+     */
+    //% block="pin A1" fixedInstance shim=pxt::getTouchButton(PIN_A1)
+    const pinA1: TouchButton;
+
+    /**
+     * Capacitive pin A2
+     */
+    //% block="pin A2" fixedInstance shim=pxt::getTouchButton(PIN_A2)
+    const pinA2: TouchButton;
+
+    /**
+     * Capacitive pin A3
+     */
+    //% block="pin A3" fixedInstance shim=pxt::getTouchButton(PIN_A3)
+    const pinA3: TouchButton;
+
+    /**
+     * Capacitive pin A4
+     */
+    //% block="pin A4" fixedInstance shim=pxt::getTouchButton(PIN_A4)
+    const pinA4: TouchButton;
+
+    /**
+     * Capacitive pin A5
+     */
+    //% block="pin A5" fixedInstance shim=pxt::getTouchButton(PIN_A5)
+    const pinA5: TouchButton;
+
+    /**
+     * Capacitive pin A6
+     */
+    //% block="pin A6" fixedInstance shim=pxt::getTouchButton(PIN_A6)
+    const pinA6: TouchButton;
+
+    /**
+     * Capacitive pin A7
+     */
+    //% block="pin A7" fixedInstance shim=pxt::getTouchButton(PIN_A7)
+    const pinA7: TouchButton;
+}

--- a/libs/adafruit-circuit-playground/ns.ts
+++ b/libs/adafruit-circuit-playground/ns.ts
@@ -1,0 +1,29 @@
+
+//% color="#d65cd6"
+namespace input {
+}
+
+//% color="#F55D3E"
+namespace music {
+
+}
+
+//% color="#00b295"
+namespace control {
+
+}
+
+//% color="#EF2D56" advanced=false
+namespace pins {
+
+}
+
+//% color="#006E90"
+namespace serial {
+
+}
+
+//% color="#40bf4a"
+namespace loops {
+
+}

--- a/libs/adafruit-circuit-playground/pxt.json
+++ b/libs/adafruit-circuit-playground/pxt.json
@@ -1,0 +1,18 @@
+{
+    "name": "circuit-playground",
+    "description": "The Adafruit Circuit Playground Express library",
+    "files": [
+        "README.md",
+        "device.d.ts",
+        "config.ts",
+        "ns.ts"
+    ],
+    "dependencies": {
+        "core": "file:../core",
+        "buttons": "file:../buttons",
+        "touch": "file:../touch",
+        "music": "file:../music",
+        "pixel": "file:../pixel"
+    },
+    "public": true
+}

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -16,6 +16,7 @@
         "libs/light",
         "libs/adafruit-trinket-m0",
         "libs/adafruit-metro-m0-express",
+        "libs/adafruit-circuit-playground",
         "libs/arduino-zero",
         "libs/arduino-mkr",
         "libs/tests",


### PR DESCRIPTION
I think if we're to prototype here for CPX, we need a CPX target. I wouldn't add it to list of boards on home page, but we can have an option in "Add package". This still needs svg and pin setup.

@pelikhan @tballmsft @abchatra comments? 