### PR TITLE
upgrading to codal 1.4.1 (webusb)

### DIFF
--- a/docs/index-ref.json
+++ b/docs/index-ref.json
@@ -1,3 +1,3 @@
 {
-    "appref": "v"
+    "appref": "v0.3.2"
 }

--- a/libs/adafruit-feather-m0-express/board.json
+++ b/libs/adafruit-feather-m0-express/board.json
@@ -1,4 +1,5 @@
 {
+    "driveDisplayName": "FEATHERBOOT",
     "visual": {
         "image": "pkg://board.svg",
         "outlineImage": "pkg://boardwireframe.svg",

--- a/libs/adafruit-gemma-m0/board.json
+++ b/libs/adafruit-gemma-m0/board.json
@@ -1,4 +1,5 @@
 {
+    "driveDisplayName": "GEMMABOOT",
     "visual": {
         "image": "pkg://board.svg",
         "outlineImage": "pkg://boardwireframe.svg",

--- a/libs/adafruit-metro-m0-express/board.json
+++ b/libs/adafruit-metro-m0-express/board.json
@@ -1,4 +1,5 @@
 {
+    "driveDisplayName": "METROBOOT",
     "visual": {
         "image": "pkg://board.svg",
         "outlineImage": "pkg://boardwireframe.svg",

--- a/libs/adafruit-trinket-m0/board.json
+++ b/libs/adafruit-trinket-m0/board.json
@@ -1,4 +1,5 @@
 {
+    "driveDisplayName": "TRINKETBOOT",
     "visual": {
         "image": "pkg://board.svg",
         "outlineImage": "pkg://boardwireframe.svg",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "@types/node": "8.0.53"
   },
   "dependencies": {
-    "pxt-common-packages": "0.18.1",
-    "pxt-core": "3.3.1"
+    "pxt-common-packages": "0.19.1",
+    "pxt-core": "3.3.2"
   },
   "scripts": {
     "test": "node node_modules/pxt-core/built/pxt.js travis"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "pxt-common-packages": "0.19.1",
-    "pxt-core": "3.3.2"
+    "pxt-core": "3.3.3"
   },
   "scripts": {
     "test": "node node_modules/pxt-core/built/pxt.js travis"

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -90,7 +90,7 @@
         "codalTarget": {
             "name": "codal-circuit-playground",
             "url": "https://github.com/lancaster-university/codal-circuit-playground",
-            "branch": "v1.3.6",
+            "branch": "v1.4.1",
             "type": "git"
         },
         "codalBinary": "CIRCUIT_PLAYGROUND",

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -59,6 +59,7 @@
     "compile": {
         "isNative": true,
         "useUF2": true,
+        "webUSB": true,
         "hasHex": true,
         "deployDrives": ".*",
         "deployFileMarker": "INFO_UF2.TXT",

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -9,5 +9,12 @@
     },
     "galleries": {
         "Boards": "boards"
+    },
+    "firmwareUrls": {
+        "adafruit-circuit-playground-express": "https://learn.adafruit.com/adafruit-circuit-playground-express/adafruit2-uf2-bootloader-details#updating-the-bootloader",
+        "adafruit-feather-m0-express": "https://learn.adafruit.com/adafruit-feather-m0-express-designed-for-circuit-python-circuitpython/uf2-bootloader-details#updating-the-bootloader",
+        "adafruit-gemma-m0": "https://learn.adafruit.com/adafruit-gemma-m0/uf2-bootloader-details#updating-the-bootloader",
+        "adafruit-metro-m0-express": "https://learn.adafruit.com/adafruit-feather-m0-express-designed-for-circuit-python-circuitpython/uf2-bootloader-details#updating-the-bootloader",
+        "adafruit-trinket-m0": "https://learn.adafruit.com/adafruit-feather-m0-express-designed-for-circuit-python-circuitpython/uf2-bootloader-details#updating-the-bootloader"
     }
 }


### PR DESCRIPTION
Tried to build against the latest CODAL / WebUSB changes.
```
../pxtapp/core/hf2.cpp: In member function 'virtual int HF2::stdRequest(UsbEndpointIn&, USBSetup&)':
../pxtapp/core/hf2.cpp:66:27: error: 'GET_DESCRIPTOR' was not declared in this scope
     if (setup.bRequest == GET_DESCRIPTOR)
```
I guess it requires https://github.com/Microsoft/pxt-common-packages/pull/196.