### PR TITLE
Music, screen fixes for pxt-32

### DIFF
--- a/libs/core---nrf52840/dal.d.ts
+++ b/libs/core---nrf52840/dal.d.ts
@@ -260,6 +260,14 @@ declare const enum DAL {
     MULTI_BUTTON_SUPRESSED_1 = 16,
     MULTI_BUTTON_SUPRESSED_2 = 32,
     MULTI_BUTTON_ATTACHED = 64,
+    // built/codal/libraries/codal-core/inc/drivers/ST7735.h
+    MADCTL_MY = 128,
+    MADCTL_MX = 64,
+    MADCTL_MV = 32,
+    MADCTL_ML = 16,
+    MADCTL_RGB = 0,
+    MADCTL_BGR = 8,
+    MADCTL_MH = 4,
     // built/codal/libraries/codal-core/inc/drivers/TouchButton.h
     TOUCH_BUTTON_CALIBRATION_PERIOD = 10,
     TOUCH_BUTTON_CALIBRATION_LINEAR_OFFSET = 2,
@@ -531,6 +539,8 @@ declare const enum DAL {
     CFG_PIN_DISPLAY_DC = 36,
     CFG_DISPLAY_WIDTH = 37,
     CFG_DISPLAY_HEIGHT = 38,
+    CFG_DISPLAY_CFG0 = 39,
+    CFG_DISPLAY_CFG1 = 40,
     CFG_PIN_A0 = 100,
     CFG_PIN_A1 = 101,
     CFG_PIN_A2 = 102,

--- a/libs/music---pwm/enums.d.ts
+++ b/libs/music---pwm/enums.d.ts
@@ -1,0 +1,11 @@
+// Auto-generated. Do not edit.
+
+
+    declare const enum SoundOutputDestination {
+    //% block="pin"
+    Pin = 1,
+    //% block="speaker"
+    Speaker = 0,
+    }
+
+// Auto-generated. Do not edit. Really.

--- a/libs/music---pwm/music.cpp
+++ b/libs/music---pwm/music.cpp
@@ -1,0 +1,38 @@
+#include "pxt.h"
+
+#define NOTE_PAUSE 20
+
+namespace music {
+
+/**
+* Play a tone through the speaker for some amount of time.
+* @param frequency pitch of the tone to play in Hertz (Hz), eg: Note.C
+* @param ms tone duration in milliseconds (ms), eg: music.beat(BeatFraction.Half)
+*/
+//% help=music/play-tone
+//% blockId=music_play_note block="play tone|at %note=device_note|for %duration=device_beat"
+//% parts="headphone" async
+//% blockNamespace=music
+//% weight=76 blockGap=8
+void playTone(int frequency, int ms) {
+  auto pitchPin = LOOKUP_PIN(SPEAKER_AMP);
+
+  if (!pitchPin)
+    return;
+
+  if (frequency <= 0) {
+    pitchPin->setAnalogValue(0);
+  } else {
+    pitchPin->setAnalogValue(512);
+    pitchPin->setAnalogPeriodUs(1000000 / frequency);
+    if (ms > 0) {
+      int d = max(1, ms - NOTE_PAUSE); // allow for short rest
+      int r = max(1, ms - d);
+      fiber_sleep(d);
+      pitchPin->setAnalogValue(0);
+      fiber_sleep(r);
+    }
+  }
+}
+
+} // namespace music

--- a/libs/music---pwm/pxt.json
+++ b/libs/music---pwm/pxt.json
@@ -1,0 +1,4 @@
+{
+    "name": "music---pwm",
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/music"
+}

--- a/libs/music---pwm/shims.d.ts
+++ b/libs/music---pwm/shims.d.ts
@@ -1,0 +1,17 @@
+// Auto-generated. Do not edit.
+declare namespace music {
+
+    /**
+     * Play a tone through the speaker for some amount of time.
+     * @param frequency pitch of the tone to play in Hertz (Hz), eg: Note.C
+     * @param ms tone duration in milliseconds (ms), eg: music.beat(BeatFraction.Half)
+     */
+    //% help=music/play-tone
+    //% blockId=music_play_note block="play tone|at %note=device_note|for %duration=device_beat"
+    //% parts="headphone" async
+    //% blockNamespace=music
+    //% weight=76 blockGap=8 shim=music::playTone
+    function playTone(frequency: int32, ms: int32): void;
+}
+
+// Auto-generated. Do not edit. Really.

--- a/libs/pxt-32/config.ts
+++ b/libs/pxt-32/config.ts
@@ -10,14 +10,19 @@ namespace config {
     export const PIN_RX = DAL.P0_30;
     export const PIN_TX = DAL.P0_29;
 
-    export const PIN_DISPLAY_MOSI = DAL.P0_3;
+    export const PIN_DISPLAY_MOSI = DAL.P0_28;
     export const PIN_DISPLAY_MISO = -1;
     export const PIN_DISPLAY_SCK = DAL.P0_4;
-    export const PIN_DISPLAY_CS = DAL.P0_28;
+    export const PIN_DISPLAY_CS = DAL.P0_3;
     export const PIN_DISPLAY_DC = DAL.P0_29;
+
+    // it's really piezo speaker, not an amp
+    export const PIN_SPEAKER_AMP = DAL.P0_2;
 
     // use 0x010248 for 128x128 screen
     export const DISPLAY_CFG0 = 0x40;
+    // use 0x083B3B for 128x128 screen
+    export const DISPLAY_CFG1 = 0x000603;
     export const DISPLAY_WIDTH = 160;
     export const DISPLAY_HEIGHT = 128;
 }

--- a/libs/pxt-32/config.ts
+++ b/libs/pxt-32/config.ts
@@ -16,7 +16,9 @@ namespace config {
     export const PIN_DISPLAY_CS = DAL.P0_28;
     export const PIN_DISPLAY_DC = DAL.P0_29;
 
-    export const DISPLAY_WIDTH = 128;
+    // use 0x010248 for 128x128 screen
+    export const DISPLAY_CFG0 = 0x40;
+    export const DISPLAY_WIDTH = 160;
     export const DISPLAY_HEIGHT = 128;
 }
 

--- a/libs/pxt-32/config.ts
+++ b/libs/pxt-32/config.ts
@@ -29,3 +29,4 @@ namespace config {
 
 
 game.setWaitAnyKey(keys.pauseUntilAnyKey)
+game.gameOverSound = () => music.playSound(music.sounds(Sounds.Wawawawaa));

--- a/libs/pxt-32/device.d.ts
+++ b/libs/pxt-32/device.d.ts
@@ -15,16 +15,16 @@ declare namespace pins {
     const P12: PwmPin;
     
     
-    //% fixedInstance shim=pxt::getPin(P0_17)
+    //% fixedInstance shim=pxt::getPin(P0_13)
     const LED1: DigitalPin;
 
-    // fixedInstance shim=pxt::getPin(P1_00)
-    // const LED2: DigitalPin;
+    //% fixedInstance shim=pxt::getPin(P0_14)
+    const LED2: DigitalPin;
 
-    //% fixedInstance shim=pxt::getPin(P0_19)
+    //% fixedInstance shim=pxt::getPin(P0_15)
     const LED3: DigitalPin;
 
-    //% fixedInstance shim=pxt::getPin(P0_20)
+    //% fixedInstance shim=pxt::getPin(P0_16)
     const LED4: DigitalPin;
 
     //% fixedInstance shim=pxt::getPin(PIN_SDA)
@@ -50,13 +50,13 @@ declare namespace input {
     //% shim=pxt::getButtonByPin(P0_11,BUTTON_ACTIVE_LOW_PULL_UP)
     const button1: Button;
     //% block="button 2" fixedInstance
-    //% shim=pxt::getButtonByPin(P0_14,BUTTON_ACTIVE_LOW_PULL_UP)
+    //% shim=pxt::getButtonByPin(P0_12,BUTTON_ACTIVE_LOW_PULL_UP)
     const button2: Button;
     //% block="button 3" fixedInstance
-    //% shim=pxt::getButtonByPin(P0_15,BUTTON_ACTIVE_LOW_PULL_UP)
+    //% shim=pxt::getButtonByPin(P0_24,BUTTON_ACTIVE_LOW_PULL_UP)
     const button3: Button;
     //% block="button 4" fixedInstance
-    //% shim=pxt::getButtonByPin(P0_16,BUTTON_ACTIVE_LOW_PULL_UP)
+    //% shim=pxt::getButtonByPin(P0_25,BUTTON_ACTIVE_LOW_PULL_UP)
     const button4: Button;
 
     //% block="button E0" fixedInstance

--- a/libs/pxt-32/pxt.json
+++ b/libs/pxt-32/pxt.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "core---nrf52832": "file:../core---nrf52840",
         "screen---st7735": "file:../screen---st7735",
+        "music---pwm": "file:../music---pwm",
         "game": "file:../game",
         "keys": "file:../keys",
         "buttons": "file:../buttons"

--- a/libs/screen---st7735/pxt.json
+++ b/libs/screen---st7735/pxt.json
@@ -1,3 +1,4 @@
 {
+    "name": "screen---st7735",
     "additionalFilePath": "../../node_modules/pxt-common-packages/libs/screen"
 }

--- a/libs/screen---st7735/screen.cpp
+++ b/libs/screen---st7735/screen.cpp
@@ -19,9 +19,14 @@ class WDisplay {
         : spi(*LOOKUP_PIN(DISPLAY_MOSI), *LOOKUP_PIN(DISPLAY_MISO), *LOOKUP_PIN(DISPLAY_SCK)),
           lcd(spi, *LOOKUP_PIN(DISPLAY_CS), *LOOKUP_PIN(DISPLAY_DC)) {
         lcd.init();
+        uint32_t cfg0 = getConfig(CFG_DISPLAY_CFG0, 0x40);
+        auto madctl = cfg0 & 0xff;
+        auto offX = (cfg0 >> 8) & 0xff;
+        auto offY = (cfg0 >> 16) & 0xff;
+        lcd.configure(madctl);
         width = getConfig(CFG_DISPLAY_WIDTH, 160);
         height = getConfig(CFG_DISPLAY_HEIGHT, 128);
-        lcd.setAddrWindow(0, 0, width, height);
+        lcd.setAddrWindow(offX, offY, width, height);
         screenBuf = new uint8_t[width * height / 2 + 20];
     }
 };

--- a/libs/screen---st7735/screen.cpp
+++ b/libs/screen---st7735/screen.cpp
@@ -20,14 +20,16 @@ class WDisplay {
           lcd(spi, *LOOKUP_PIN(DISPLAY_CS), *LOOKUP_PIN(DISPLAY_DC)) {
         lcd.init();
         uint32_t cfg0 = getConfig(CFG_DISPLAY_CFG0, 0x40);
+        uint32_t frmctr1 = getConfig(CFG_DISPLAY_CFG1, 0x000603);
         auto madctl = cfg0 & 0xff;
         auto offX = (cfg0 >> 8) & 0xff;
         auto offY = (cfg0 >> 16) & 0xff;
-        lcd.configure(madctl);
+        lcd.configure(madctl, frmctr1);
         width = getConfig(CFG_DISPLAY_WIDTH, 160);
         height = getConfig(CFG_DISPLAY_HEIGHT, 128);
         lcd.setAddrWindow(offX, offY, width, height);
         screenBuf = new uint8_t[width * height / 2 + 20];
+        lastImg = NULL;
     }
 };
 

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -14,6 +14,7 @@
         "libs/screen---st7735",
         "libs/game",
         "libs/music",
+        "libs/music---pwm",
         "libs/pixel",
         "libs/buttons",
         "libs/touch",
@@ -165,7 +166,7 @@
                 "codalTarget": {
                     "name": "codal-nrf52840-dk",
                     "url": "https://github.com/mmoskal/codal-nrf52840-dk",
-                    "branch": "v0.0.10",
+                    "branch": "v0.0.11",
                     "type": "git"
                 },
                 "codalBinary": "NRF52840_DK",

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -165,7 +165,7 @@
                 "codalTarget": {
                     "name": "codal-nrf52840-dk",
                     "url": "https://github.com/mmoskal/codal-nrf52840-dk",
-                    "branch": "v0.0.9",
+                    "branch": "v0.0.10",
                     "type": "git"
                 },
                 "codalBinary": "NRF52840_DK",


### PR DESCRIPTION
* change pin assignments for pxt-32 for easier wiring
* fixes in `screen---st7735` (mostly codal-side)
* make screen more configurable
* add `music---pwm`