### PR TITLE
Update JacDac for LEDs

### DIFF
--- a/libs/core---samd51/dal.d.ts
+++ b/libs/core---samd51/dal.d.ts
@@ -1,7 +1,7 @@
 // Auto-generated. Do not edit.
 declare const enum DAL {
     // /libraries/codal-core/inc/JACDAC/JACDAC.h
-    JD_VERSION = 2,
+    JD_VERSION = 3,
     JD_SERIAL_MAX_BUFFERS = 10,
     JD_SERIAL_RECEIVING = 2,
     JD_SERIAL_TRANSMITTING = 4,
@@ -695,9 +695,7 @@ declare const enum DAL {
     REF_TAG_BUFFER = 2,
     REF_TAG_IMAGE = 3,
     REF_TAG_USER = 32,
-    // /pxtapp/hf2dbg.h
-    HF2DBG_H = 1,
-    // /pxtapp/pins.h
+    // /pxtapp/configkeys.h
     CFG_PIN_ACCELEROMETER_INT = 1,
     CFG_PIN_ACCELEROMETER_SCL = 2,
     CFG_PIN_ACCELEROMETER_SDA = 3,
@@ -763,6 +761,8 @@ declare const enum DAL {
     CFG_PIN_JACK_BZEN = 63,
     CFG_PIN_JACK_PWREN = 64,
     CFG_PIN_JACK_SND = 65,
+    CFG_PIN_JACK_BUSLED = 66,
+    CFG_PIN_JACK_COMMLED = 67,
     CFG_PIN_BTNMX_LATCH = 66,
     CFG_PIN_BTNMX_CLOCK = 67,
     CFG_PIN_BTNMX_DATA = 68,
@@ -810,6 +810,12 @@ declare const enum DAL {
     CFG_DEFAULT_BUTTON_MODE = 202,
     CFG_SWD_ENABLED = 203,
     CFG_FLASH_BYTES = 204,
+    CFG_RAM_BYTES = 205,
+    CFG_SYSTEM_HEAP_BYTES = 206,
+    CFG_LOW_MEM_SIMULATION_KB = 207,
+    // /pxtapp/hf2dbg.h
+    HF2DBG_H = 1,
+    // /pxtapp/pins.h
     BUTTON_ACTIVE_HIGH_PULL_DOWN = 17,
     BUTTON_ACTIVE_HIGH_PULL_UP = 33,
     BUTTON_ACTIVE_HIGH_PULL_NONE = 49,

--- a/libs/music/shims.d.ts
+++ b/libs/music/shims.d.ts
@@ -24,7 +24,8 @@ declare namespace music {
     //% parts="speaker"
     //% volume.min=0 volume.max=256
     //% help=music/set-volume
-    //% weight=70 shim=music::setVolume
+    //% weight=70
+    //% group="Volume" shim=music::setVolume
     function setVolume(volume: int32): void;
 
     /**
@@ -36,7 +37,8 @@ declare namespace music {
     //% blockId=music_play_note block="play tone|at %note=device_note|for %duration=device_beat"
     //% parts="headphone" async
     //% blockNamespace=music
-    //% weight=76 blockGap=8 shim=music::playTone
+    //% weight=76 blockGap=8
+    //% group="Tone" shim=music::playTone
     function playTone(frequency: int32, ms: int32): void;
 }
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/web-bluetooth": "0.0.4"
   },
   "dependencies": {
-    "pxt-common-packages": "5.1.35",
+    "pxt-common-packages": "5.1.38",
     "pxt-core": "5.2.11"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "@types/web-bluetooth": "0.0.4"
   },
   "dependencies": {
-    "pxt-common-packages": "5.1.30",
-    "pxt-core": "5.2.10"
+    "pxt-common-packages": "5.1.35",
+    "pxt-core": "5.2.11"
   },
   "scripts": {
     "test": "node node_modules/pxt-core/built/pxt.js travis"

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "@types/web-bluetooth": "0.0.4"
   },
   "dependencies": {
-    "pxt-common-packages": "5.1.38",
-    "pxt-core": "5.2.11"
+    "pxt-common-packages": "5.1.41",
+    "pxt-core": "5.2.13"
   },
   "scripts": {
     "test": "node node_modules/pxt-core/built/pxt.js travis"

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -217,7 +217,7 @@
                 "vtableShift": 3,
                 "useUF2": false,
                 "webUSB": false,
-                "gc": false
+                "gc": true
             },
             "compileService": {
                 "codalTarget": {

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -124,7 +124,7 @@
             "branch": "v1.5.6",
             "type": "git",
             "branches": {
-                "https://github.com/lancaster-university/codal-core": "10eae25b5bc19ca98934a67292e80e1faf82dbd5"
+                "https://github.com/lancaster-university/codal-core": "ec620ab3ad9971c5b57259fa91376331c682f1ca"
             }
         },
         "codalBinary": "CIRCUIT_PLAYGROUND",

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -124,7 +124,7 @@
             "branch": "v1.5.6",
             "type": "git",
             "branches": {
-                "https://github.com/lancaster-university/codal-core": "ec620ab3ad9971c5b57259fa91376331c682f1ca"
+                "https://github.com/lancaster-university/codal-core": "5bfe583b1982a55d59e09dd0217155e6b7b5898c"
             }
         },
         "codalBinary": "CIRCUIT_PLAYGROUND",


### PR DESCRIPTION
@mmoskal getting this build issue on red-bear. is ``gcAllocateArray`` guarded by platform?

```
[ 98%] Linking CXX executable BLE_NANO
CMakeFiles/BLE_NANO.dir/pxtapp/base/pxt.cpp.o: In function `pxt::Segment::growByMin(unsigned short)':
/src/pxtapp/base/pxt.cpp:206: undefined reference to `pxt::gcAllocateArray(int)'
CMakeFiles/BLE_NANO.dir/pxtapp/base/pxt.cpp.o: In function `pxt::exec_binary(unsigned int*)':
/src/pxtapp/base/pxt.cpp:457: undefined reference to `pxt::gcPermAllocate(int)'
collect2: error: ld returned 1 exit status
make[2]: *** [BLE_NANO] Error 1
make[1]: *** [CMakeFiles/BLE_NANO.dir/all] Error 2
```