### PR TITLE
Update README Repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Make sure to pull changes from all repos regularly. More instructions are at htt
 ## Repos 
 
 The pxt-microbit target depends on several other repos. The main ones are:
-- https://github.com/Microsoft/pxt, the PXT framework
-- https://github.com/Microsoft/pxt-commmon-packages, common APIs accross various MakeCode editors
+- https://github.com/microsoft/pxt, the PXT framework
+- https://github.com/microsoft/pxt-commmon-packages, common APIs accross various MakeCode editors
 - https://github.com/lancaster-university/codal-core, CODAL core project
 - https://github.com/lancaster-university/codal-mbed, mbed layer
 - https://github.com/lancaster-university/codal-samd21, CODAL SAMD21 layer


### PR DESCRIPTION
fix the URL links to the Microsoft PXT repos

I could not access the pxt repos to investigate how animations were coded. The proper URLs do not capitalize Microsoft, whereas the current links do which result in a 404 page when clicking the link. 