### PR TITLE
Updated paths for CODAL local build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ If you are missing tools, you will be notified by the build script.
 pxt build --local --force
 ```
 
-* go to the ``built/codal`` folder and open all CODAL in a new Visual Studio Code instance
+* go to the ``built/dockercodal`` folder and open all CODAL in a new Visual Studio Code instance
 
 ```
-cd built/codal
+cd built/dockercodal
 code libraries/*
 ```
 


### PR DESCRIPTION
As per what Windows 10 does.  Have not checked "to build CODAL directly, run built/codal" command.