### PR TITLE
[pxt-cli] bump version to v0.15.70

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-maker",
-    "version": "0.15.69",
+    "version": "0.15.70",
     "description": "Microsoft MakeCode Maker Boards",
     "public": true,
     "keywords": [


### PR DESCRIPTION
__Do not edit the PR title.__
It was automatically generated by `pxt bump` and must follow a specific pattern.
GitHub workflows rely on it to trigger version tagging and publishing to npm.