### PR TITLE
use deploy key in actions workflow

### DIFF
--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: 20.x
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: npm install
         run: |
@@ -74,7 +74,7 @@ jobs:
           node-version: 20.x
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: npm install
         run: |

--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -85,11 +85,39 @@ jobs:
       - name: pxt ci (with publish capability)
         run: |
           pxt ci --publish
+
+      - name: Clone release repo
+        uses: actions/checkout@main
+        with:
+          repository: ${{ secrets.BUILT_REPO_NAME }}
+          path: tmp/releases/release
+          fetch-depth: 3
+          fetch-tags: true
+          ssh-key: ${{ secrets.BUILT_REPO_DEPLOY_KEY }}
+
+      - name: Read release info
+        id: release_info
+        run: |
+          content=`cat tmp/releases/release.json`
+          echo "::set-output name=releaseInfo::$content"
+
+      - name: Push artifacts to release repo
+        run: |
+          cp -r tmp/releases/built/ tmp/releases/release/
+          git config user.name "github-actions"
+          git config user.email "github-actions@users.noreply.github.com"
+          cd tmp/releases/release
+          git add .
+          git commit -m "Release ${{fromJson(steps.release_info.outputs.releaseInfo).tag}} from ${{fromJson(steps.release_info.outputs.releaseInfo).url}}"
+          git tag ${{fromJson(steps.release_info.outputs.releaseInfo).tag}}
+          git push
+          git push --tags
+
         env:
           CROWDIN_KEY: ${{ secrets.CROWDIN_KEY }}
           PXT_ACCESS_TOKEN: ${{ secrets.PXT_ACCESS_TOKEN }}
-          PXT_RELEASE_REPO: ${{ secrets.PXT_RELEASE_REPO }}
           NPM_PUBLISH: true
           CHROME_BIN: chromium-browser
           DISPLAY: :99.0
           CI: true
+          PXT_SKIP_GIT_COMMIT: true

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     },
     "dependencies": {
         "pxt-common-packages": "13.2.3",
-        "pxt-core": "13.1.4"
+        "pxt-core": "13.1.5"
     },
     "scripts": {
         "test": "node node_modules/pxt-core/built/pxt.js travis",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     },
     "dependencies": {
         "pxt-common-packages": "13.2.3",
-        "pxt-core": "13.1.3"
+        "pxt-core": "13.1.4"
     },
     "scripts": {
         "test": "node node_modules/pxt-core/built/pxt.js travis",

--- a/package.json
+++ b/package.json
@@ -50,10 +50,18 @@
     },
     "dependencies": {
         "pxt-common-packages": "13.2.3",
-        "pxt-core": "12.2.8"
+        "pxt-core": "13.1.3"
     },
     "scripts": {
         "test": "node node_modules/pxt-core/built/pxt.js travis",
         "svgo": "glob-exec --foreach \"**/boardhd.svg\" -- \"svgo --config=svgo.yml {{file}} -o {{file.dir}}/board.svg \""
+    },
+    "overrides": {
+        "@blockly/field-grid-dropdown": {
+            "blockly": "13.1.1"
+        },
+        "@blockly/plugin-workspace-search": {
+            "blockly": "13.1.1"
+        }
     }
 }


### PR DESCRIPTION
updating the primary github actions workflow to use a deploy key instead of the pxtravis token. this requires changes in pxt-core, which i will be opening a pr for shortly.

also requires two new environment variables:

* BUILT_REPO - the name of the built repo, e.g. microsoft/pxt-maker-built
* BUILT_REPO_DEPLOY_KEY - the deploy ssh key for that repo

the PXT_RELEASE_REPO variable will be deprecated