### PR TITLE
fix cp command

### DIFF
--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Push artifacts to release repo
         run: |
-          cp -r tmp/releases/built/ tmp/releases/release/
+          cp -a tmp/releases/built/. tmp/releases/release
           cd tmp/releases/release
           git config user.name "github-actions"
           git config user.email "github-actions@users.noreply.github.com"


### PR DESCRIPTION
make sure we copy the files into the root of releases/release instead of releases/release/built

i was a little confused as to why this still didn't result in a commit, but then i realized that built/ is probably gitignored